### PR TITLE
add support for memcached flush_all command

### DIFF
--- a/etc/php/pear/memcached.php
+++ b/etc/php/pear/memcached.php
@@ -530,6 +530,29 @@ class Memcached
     }
 
     /**
+     * Flush the cache
+     *
+     * @return  boolean
+     */
+    public function flush()
+    {
+        $this->writeSocket('flush_all') ;
+
+        $s = $this->readSocket();
+
+        if ('OK' == $s) {
+            $this->resultCode = Memcached::RES_SUCCESS;
+            $this->resultMessage = '';
+            return true;
+
+        } else {
+            $this->resultCode = Memcached::RES_FAILURE;
+            $this->resultMessage = 'Flush fail.';
+            return false;
+        }
+    }
+
+    /**
      * Write data to socket
      *
      * @param   string  $cmd


### PR DESCRIPTION
This fixes 'Call to undefined method Memcached::flush()' errors when attempting to flush cache (Laravel's Cache facade has a flush() method which does this).

Memcached flush_all command:
https://github.com/memcached/memcached/wiki/Commands#flushall