### PR TITLE
Update versions and add Backdrop and Grav CMS

### DIFF
--- a/bin/laragon/sites.manifest.conf
+++ b/bin/laragon/sites.manifest.conf
@@ -5,20 +5,30 @@ Cached=true
 # Blank: an empty project
 Blank=
 
-# WordPress
-WordPress=https://wordpress.org/latest.tar.gz 
+# Wordpress
+Wordpress=https://wordpress.org/latest.tar.gz 
 
 # Joomla
-Joomla=https://github.com/joomla/joomla-cms/releases/download/3.8.11/Joomla_3.8.11-Stable-Full_Package.tar.gz
+Joomla=https://github.com/joomla/joomla-cms/releases/download/3.9.12/Joomla_3.9.12-Stable-Full_Package.tar.gz
 
 # Prestashop
-Prestashop=https://github.com/PrestaShop/PrestaShop/releases/download/1.7.4.2/prestashop_1.7.4.2.zip
+Prestashop=https://github.com/PrestaShop/PrestaShop/releases/download/1.7.6.1/prestashop_1.7.6.1.zip
+
+# Backdrop (Drupal 7 fork)
+Backdrop=https://github.com/backdrop/backdrop/releases/download/1.14.1/backdrop.zip
+
+------------------------------------------------------
+
+# Grav (Flat-file CMS)
+Grav=https://getgrav.org/download/core/grav/1.6.16/grav-v1.6.16.zip
+
+Grav+Admin=https://getgrav.org/download/core/grav-admin/1.6.16/grav-admin-v1.6.16.zip
 
 ------------------------------------------------------
 
 # Drupal
-Drupal 8=https://ftp.drupal.org/files/projects/drupal-8.5.5.tar.gz
-### Drupal 7=https://ftp.drupal.org/files/projects/drupal-7.59.tar.gz
+Drupal 8=https://ftp.drupal.org/files/projects/drupal-8.7.8.tar.gz
+### Drupal 7=https://ftp.drupal.org/files/projects/drupal-7.67.tar.gz
 
 ------------------------------------------------------
 
@@ -26,9 +36,9 @@ Drupal 8=https://ftp.drupal.org/files/projects/drupal-8.5.5.tar.gz
 
 Laravel=composer create-project laravel/laravel %s --prefer-dist
  
-Laravel 7z=https://github.com/leokhoa/quick-create-laravel/releases/download/5.6.21/laravel-5.6.21.7z
+Laravel 7z=https://github.com/leokhoa/quick-create-laravel/releases/download/5.7.15/laravel-5.7.15.7z
 
-### Laravel dev-develop=composer create-project laravel/laravel %s dev-develop
+###Laravel dev-develop=composer create-project laravel/laravel %s dev-develop
 ### Laravel 4=composer create-project laravel/laravel  %s 4.2 --prefer-dist	
 Lumen=composer create-project laravel/lumen  %s --prefer-dist
 


### PR DESCRIPTION
Backdrop (Drupal 7 fork)
[https://backdropcms.org/](https://backdropcms.org/)

Grav (Flat-file CMS)
[https://getgrav.org/](https://getgrav.org/)