### PR TITLE
better cmder integration, allows upgrading cmder

### DIFF
--- a/bin/cmder/config/profile.d/laragon.cmd
+++ b/bin/cmder/config/profile.d/laragon.cmd
@@ -1,56 +1,5 @@
 @echo off
 
-echo %CMDER_ROOT% | findstr /i "\laragon\bin\cmder"
-if "%ERRORLEVEL%" equ "0" call :laragon
-exit /b 0
-
-:laragon
-    :: Laragon Start -------------------------------------------------------------------
-
-    if exist "%CMDER_ROOT%\..\git" (
-        set "GIT_INSTALL_ROOT=%CMDER_ROOT%\..\git"
-    )
-    
-    if exist "%GIT_INSTALL_ROOT%\post-install.bat" (
-        echo Running Git for Windows one time Post Install....
-    	pushd "%GIT_INSTALL_ROOT%"
-        call "%GIT_INSTALL_ROOT%\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat
-    	@DEL post-install.bat
-    
-    	popd
-        :: cd /d %USERPROFILE%
-    	rem
-    )
-    
-    for /f "delims=" %%i in ("%CMDER_ROOT%\..\..\usr") do set USER_DIR=%%~fi
-    set USR_DIR=%USER_DIR%
-    
-    if exist "%CMDER_ROOT%\..\laragon\laragon.cmd" (
-        :: call Laragon own commands
-        call "%CMDER_ROOT%\..\laragon\laragon.cmd"
-    )
-    
-    
-    if exist "%USER_DIR%\user.cmd" (
-        rem create this file and place your own command in there
-        call "%USER_DIR%\user.cmd"
-    ) else (
-        echo Creating user startup file: "%USER_DIR%\user.cmd"
-        (
-        echo :: use this file to run your own startup commands
-        echo :: use  in front of the command to prevent printing the command
-        echo.
-        echo :: call start-ssh-agent.cmd
-        echo :: set PATH=%%USER_DIR%%\bin\whatever;%%PATH%%
-    	echo.
-    	echo :: cmd /c start http://localhost 
-        echo.
-        ) > "%USER_DIR%\user.cmd"
-        
-        :: cd /d "%CMDER_ROOT%\..\..\www"
-    	rem
-    )
-    
-    :: Laragon End -------------------------------------------------------------------
-    
+echo %CMDER_ROOT% | findstr /i "\laragon\bin\cmder" >nul
+if "%ERRORLEVEL%" equ "0" call %cmder_root%\..\..\etc\cmder\laragon.cmd
 exit /b 0

--- a/bin/cmder/config/profile.d/laragon.cmd
+++ b/bin/cmder/config/profile.d/laragon.cmd
@@ -1,6 +1,5 @@
 @echo off
 
-
 echo %CMDER_ROOT% | findstr /i "laragon" >nul
 if "%ERRORLEVEL%" equ "0" call %cmder_root%\..\..\etc\cmder\laragon.cmd
 exit /b 0

--- a/bin/cmder/config/profile.d/laragon.cmd
+++ b/bin/cmder/config/profile.d/laragon.cmd
@@ -1,0 +1,56 @@
+@echo off
+
+echo %CMDER_ROOT% | findstr /i "\laragon\bin\cmder"
+if "%ERRORLEVEL%" equ "0" call :laragon
+exit /b 0
+
+:laragon
+    :: Laragon Start -------------------------------------------------------------------
+
+    if exist "%CMDER_ROOT%\..\git" (
+        set "GIT_INSTALL_ROOT=%CMDER_ROOT%\..\git"
+    )
+    
+    if exist "%GIT_INSTALL_ROOT%\post-install.bat" (
+        echo Running Git for Windows one time Post Install....
+    	pushd "%GIT_INSTALL_ROOT%"
+        call "%GIT_INSTALL_ROOT%\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat
+    	@DEL post-install.bat
+    
+    	popd
+        :: cd /d %USERPROFILE%
+    	rem
+    )
+    
+    for /f "delims=" %%i in ("%CMDER_ROOT%\..\..\usr") do set USER_DIR=%%~fi
+    set USR_DIR=%USER_DIR%
+    
+    if exist "%CMDER_ROOT%\..\laragon\laragon.cmd" (
+        :: call Laragon own commands
+        call "%CMDER_ROOT%\..\laragon\laragon.cmd"
+    )
+    
+    
+    if exist "%USER_DIR%\user.cmd" (
+        rem create this file and place your own command in there
+        call "%USER_DIR%\user.cmd"
+    ) else (
+        echo Creating user startup file: "%USER_DIR%\user.cmd"
+        (
+        echo :: use this file to run your own startup commands
+        echo :: use  in front of the command to prevent printing the command
+        echo.
+        echo :: call start-ssh-agent.cmd
+        echo :: set PATH=%%USER_DIR%%\bin\whatever;%%PATH%%
+    	echo.
+    	echo :: cmd /c start http://localhost 
+        echo.
+        ) > "%USER_DIR%\user.cmd"
+        
+        :: cd /d "%CMDER_ROOT%\..\..\www"
+    	rem
+    )
+    
+    :: Laragon End -------------------------------------------------------------------
+    
+exit /b 0

--- a/bin/cmder/config/profile.d/laragon.cmd
+++ b/bin/cmder/config/profile.d/laragon.cmd
@@ -1,5 +1,6 @@
 @echo off
 
-echo %CMDER_ROOT% | findstr /i "\laragon\bin\cmder" >nul
+
+echo %CMDER_ROOT% | findstr /i "laragon" >nul
 if "%ERRORLEVEL%" equ "0" call %cmder_root%\..\..\etc\cmder\laragon.cmd
 exit /b 0

--- a/bin/cmder/vendor/init.bat
+++ b/bin/cmder/vendor/init.bat
@@ -165,64 +165,11 @@ if defined CMDER_START (
     cd /d "%CMDER_START%"
 )
 
-:: Laragon Start -------------------------------------------------------------------
-
-
-if exist "%CMDER_ROOT%\..\git" (
-    set "GIT_INSTALL_ROOT=%CMDER_ROOT%\..\git"
-)
-
-if exist "%GIT_INSTALL_ROOT%\post-install.bat" (
-    echo Running Git for Windows one time Post Install....
-	pushd "%GIT_INSTALL_ROOT%"
-    call "%GIT_INSTALL_ROOT%\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat
-	@DEL post-install.bat
-
-	popd
-    :: cd /d %USERPROFILE%
-	rem
-)
-
-for /f "delims=" %%i in ("%CMDER_ROOT%\..\..\usr") do set USER_DIR=%%~fi
-set USR_DIR=%USER_DIR%
-
-
-
-if exist "%CMDER_ROOT%\..\laragon\laragon.cmd" (
-    :: call Laragon own commands
-    call "%CMDER_ROOT%\..\laragon\laragon.cmd"
-)
-
-if exist "%USER_DIR%\user.cmd" (
-    rem create this file and place your own command in there
-    call "%USER_DIR%\user.cmd"
-) else (
-    echo Creating user startup file: "%USER_DIR%\user.cmd"
-    (
-    echo :: use this file to run your own startup commands
-    echo :: use  in front of the command to prevent printing the command
-    echo.
-    echo :: call %%GIT_INSTALL_ROOT%%/cmd/start-ssh-agent.cmd
-    echo :: set PATH=%%USER_DIR%%\bin\whatever;%%PATH%%
-	echo.
-	echo :: cmd /c start http://localhost 
-    echo.
-    ) > "%USER_DIR%\user.cmd"
-    
-    :: cd /d "%CMDER_ROOT%\..\..\www"
-	rem
-)
-
-:: Laragon End -------------------------------------------------------------------
-
 if not '"%1"'=='""""' if not '"%1"'=='""' (
 	call "%1"
 ) else (
 	rem 
 )
-
-
-
 
 exit /b
 

--- a/etc/cmder/laragon.cmd
+++ b/etc/cmder/laragon.cmd
@@ -1,0 +1,51 @@
+@echo off
+
+:: Laragon Start -------------------------------------------------------------------
+
+if exist "%CMDER_ROOT%\..\git" (
+    set "GIT_INSTALL_ROOT=%CMDER_ROOT%\..\git"
+)
+
+if exist "%GIT_INSTALL_ROOT%\post-install.bat" (
+    echo Running Git for Windows one time Post Install....
+	pushd "%GIT_INSTALL_ROOT%"
+    call "%GIT_INSTALL_ROOT%\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat
+	@DEL post-install.bat
+
+	popd
+    :: cd /d %USERPROFILE%
+	rem
+)
+
+for /f "delims=" %%i in ("%CMDER_ROOT%\..\..\usr") do set USER_DIR=%%~fi
+set USR_DIR=%USER_DIR%
+
+if exist "%CMDER_ROOT%\..\laragon\laragon.cmd" (
+    :: call Laragon own commands
+    call "%CMDER_ROOT%\..\laragon\laragon.cmd"
+)
+
+
+if exist "%USER_DIR%\user.cmd" (
+    rem create this file and place your own command in there
+    call "%USER_DIR%\user.cmd"
+) else (
+    echo Creating user startup file: "%USER_DIR%\user.cmd"
+    (
+    echo :: use this file to run your own startup commands
+    echo :: use  in front of the command to prevent printing the command
+    echo.
+    echo :: call start-ssh-agent.cmd
+    echo :: set PATH=%%USER_DIR%%\bin\whatever;%%PATH%%
+	echo.
+	echo :: cmd /c start http://localhost 
+    echo.
+    ) > "%USER_DIR%\user.cmd"
+    
+    :: cd /d "%CMDER_ROOT%\..\..\www"
+	rem
+)
+
+:: Laragon End -------------------------------------------------------------------
+    
+exit /b 0


### PR DESCRIPTION
# Allows Cmder to be Upgraded in Laragon.

### Changes

- Move Laragon Cmder init logic from `%cmder_root%\vendor\init.bat` to `[laragon]\etc\cmder\laragon.cmd`
  - Putting the file here allows Laragon to have full control of this file.
  - Allows users to maintain full control of `%cmder_root%\config\*` which is a Cmder team practice.
- Add `%cmder_root%\config\profile.d\laragon.cmd` as a shim to call `[laragon]\etc\cmder\laragon.cmd` if Cmder is embedded in Laragon.
  - Looking for `laragon` in the in the `%cmder_root%` path allows a user to share via symlink an external Cmder folder into Laragon.  This is how I am testing and it works great.
    - Allows updating a single Cmder folder to update both `[Laragon]\bin\Cmder` and external `Cmder` installs.

### Suggestions

- Use `Cmder.exe` not `cmder.bat` to launch Cmder from Laragon because it does some things to manage Conemu settings to make it upgrade safe so settings changes via Conemu GUI are not lost on upgrades.
  - I see a `cmder.bat` in laragon but don't think it is actually used because I deleted it in mine and all still works.
- Add code to Laragon that follows the Cmder [Upgrade](https://github.com/cmderdev/cmder#upgrading) instructions so users can upgrade with one click of Laragon menu.
- Update to latest Cmder in Laragon.  Entirely up to you but this allows Cmder to be a drop in replacement for what is in Laragon.


