### PR TITLE
Update PhpMyAdmin to 5.1.1

### DIFF
--- a/usr/packages.conf
+++ b/usr/packages.conf
@@ -5,7 +5,7 @@ php=https://windows.php.net/downloads/releases/php-7.3.3-Win32-VC15-x64.zip
 apache=https://home.apache.org/~steffenal/VC15/binaries/httpd-2.4.38-win64-VC15.zip
 
 # phpMyAdmin
-*phpmyadmin=https://files.phpmyadmin.net/phpMyAdmin/4.9.5/phpMyAdmin-4.9.5-english.zip
+*https://files.phpmyadmin.net/phpMyAdmin/5.1.1/phpMyAdmin-5.1.1-all-languages.zip
 
 # MariaDB 
 # mariadb10.3=https://downloads.mariadb.org/interstitial/mariadb-10.3.13/winx64-packages/mariadb-10.3.13-winx64.zip/from/https%3A//mirrors.nxthost.com/mariadb/?serve


### PR DESCRIPTION
## **The problem:**
When I install the current Laragon's PhpMyAdmin version, I got a bunch of erros of deprecated PHP methods.

## **Solution:**
Upgrade to the latest [PhpMyAdmin](https://www.phpmyadmin.net/) version.