### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+bin/laragon/laragon.log
+
+data
+
+etc/apache2/sites-enabled
+etc/nginx/*
+!etc/nginx/alias
+!etc/nginx/php_upstream.conf
+
+tmp
+
+usr/tpl
+
+www/*
+!www/index.php


### PR DESCRIPTION
I just setup Laragon on my local machine and added some newer PHP and MySQL Versions since the stuff in Laragon is heavily outdated.

I noticed this repository doesn't have a `.gitignore`, I think this one will do the trick,