### PR TITLE
Fixed mariadb rest-api download link style

### DIFF
--- a/usr/packages.conf
+++ b/usr/packages.conf
@@ -5,10 +5,11 @@ php=https://windows.php.net/downloads/releases/php-7.3.3-Win32-VC15-x64.zip
 apache=https://home.apache.org/~steffenal/VC15/binaries/httpd-2.4.38-win64-VC15.zip
 
 # phpMyAdmin
-*phpmyadmin=https://files.phpmyadmin.net/phpMyAdmin/4.9.5/phpMyAdmin-4.9.5-english.zip
+*phpmyadmin=https://files.phpmyadmin.net/phpMyAdmin/5.2.0/phpMyAdmin-5.2.0-english.zip
 
 # MariaDB 
-# mariadb10.3=https://downloads.mariadb.org/interstitial/mariadb-10.3.13/winx64-packages/mariadb-10.3.13-winx64.zip/from/https%3A//mirrors.nxthost.com/mariadb/?serve
+# mariadb10.3=http://downloads.mariadb.org/rest-api/mariadb/10.0.3/mariadb-10.0.3-winx64.zip
+# mariadb10.5.4=http://downloads.mariadb.org/rest-api/mariadb/10.5.4/mariadb-10.5.4-winx64.zip
 # mysql-8.0=https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.15-winx64.zip
 mysql-5.7=https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.25-winx64.zip
 *git=https://github.com/leokhoa/laragon-packages/releases/download/4.0/git-2.19.2.zip


### PR DESCRIPTION
The Quick add will not download mariadb with default provided link