### PR TITLE
Documentation for tutorials

### DIFF
--- a/documentation/how-to-add-another-nginx-verison.md
+++ b/documentation/how-to-add-another-nginx-verison.md
@@ -1,0 +1,41 @@
+## How to add another Nginx version
+
+#### Table of Contents  
+[Step 1: Downloading Nginx](#downloading-nginx)  
+[Step 2: Adding new Nginx version to Laragon](#adding-nginx-version-to-laragon)  
+[Step 3: Switching to the new Nginx version](#switching-nginx-version)  
+
+<a name="downloading-nginx"/>
+
+### Step 1: Downloading Nginx
+
+Visit https://nginx.org/en/download.html for the latest version of Nginx.
+
+Download your desired version of Nginx, for example the **Mainline version**.
+
+In this case we'll download `nginx/Windows-1.23.3`
+
+<a name="adding-nginx-version-to-laragon"/>
+
+### Step 2: Adding new Nginx version to Laragon
+
+Go to the `/bin/nginx` folder inside your Laragon installation and extract the `nginx-1.23.3.zip` you've just downloaded inside this folder.
+
+![image](https://user-images.githubusercontent.com/25492573/225001814-484d61e3-c30c-4630-89cc-6dbf38bd44ca.png)
+
+_Example of how it might look_
+
+<a name="switching-nginx-version"/>
+
+### Step 3: Switching to the new Nginx version
+To switch your Nginx version in Laragon is really simple.
+
+First you have to make sure you're actually using the Nginx service. To do this, go to your `Preferences` inside Laragon and go to the `Services & Ports` tab.
+Uncheck the Apache checkbox and check the Nginx checkbox. I personally switch my port from `8080` to `80` and enable SSL with port `443`.
+
+After this is done, Nginx will be visible in your dropdown.
+
+All you have to do is go to:
+ _Laragon > Menu > Nginx > Version [current verison] > Select your desired version from this list_
+
+![image](https://user-images.githubusercontent.com/25492573/225002962-abf692fc-729b-404b-a643-ba28fafd90f6.png)

--- a/documentation/how-to-add-another-php-version.md
+++ b/documentation/how-to-add-another-php-version.md
@@ -6,9 +6,6 @@
 [Step 3: Switching to the new PHP version](#switching-php-version)  
 [Step 4: Updating PHP Environment Variable Path](#updating-environment-variable-path)  
 
-
-
-
 <a name="downloading-php-binaries"/>
 
 ### Step 1: Downloading PHP binaries
@@ -25,7 +22,9 @@ For example: [php-8.2.3-Win32-vs16-x64.zip](https://windows.php.net/downloads/re
 ### Step 2: Adding new PHP version to Laragon
 
 Go to the `/bin/php` folder inside your Laragon installation and extract the `php-8.2.3-Win32-vs16-x64.zip` you've just downloaded inside it's own folder.
+
 ![image](https://user-images.githubusercontent.com/25492573/224986199-cf6340b3-a456-4760-a11d-5552cdff9ed0.png)
+
 _Example of how it might look_
 
 <a name="switching-php-version"/>
@@ -34,6 +33,7 @@ _Example of how it might look_
 To switch your PHP version in Laragon is really simple.
 All you have to do is go to:
  _Laragon > Menu > PHP > Version [current verison] > Select your desired version from this list_
+
 ![image](https://user-images.githubusercontent.com/25492573/224986903-1d57e8ae-4cc3-4cae-a242-f51519d318b9.png)
 
 
@@ -44,10 +44,13 @@ _You have to do this step every time you switch between PHP versions._
 If you use PHP through the CLI (for example `php artisan serve` with Laravel) it's important that you also change the PATH in your environment variables.
 
 Laragon allows you to quickly do this by going to:
+
 ![image](https://user-images.githubusercontent.com/25492573/224987455-fb6c998e-915b-4f1f-a102-da62a7aa9a3c.png)
+
  _Laragon > Menu > Tools > Path > Add Laragon to Path_
 
 This will automatically add everything from your Laragon installation to the PATH
+
 ![image](https://user-images.githubusercontent.com/25492573/224990138-26b717cd-98aa-48c0-adc0-1ddd3ce8be5c.png)
 
 Make sure that you restart your terminal for these changes to take place. Run the command `php -v` to make sure you're on the correct version.

--- a/documentation/how-to-add-another-php-version.md
+++ b/documentation/how-to-add-another-php-version.md
@@ -1,0 +1,53 @@
+## How to add another PHP version
+
+#### Table of Contents  
+[Step 1: Downloading PHP binaries](#downloading-php-binaries)  
+[Step 2: Adding new PHP version to Laragon](#adding-php-version-to-laragon)  
+[Step 3: Switching to the new PHP version](#switching-php-version)  
+[Step 4: Updating PHP Environment Variable Path](#updating-environment-variable-path)  
+
+
+
+
+<a name="downloading-php-binaries"/>
+
+### Step 1: Downloading PHP binaries
+
+Visit https://windows.php.net/download/ for the latest versions of PHP or go to https://windows.php.net/downloads/releases/archives/ for older versions of PHP.
+
+Download the **Thread Safe** version of the PHP version you need.
+
+For example: [php-8.2.3-Win32-vs16-x64.zip](https://windows.php.net/downloads/releases/php-8.2.3-Win32-vs16-x64.zip)
+
+
+<a name="adding-php-version-to-laragon"/>
+
+### Step 2: Adding new PHP version to Laragon
+
+Go to the `/bin/php` folder inside your Laragon installation and extract the `php-8.2.3-Win32-vs16-x64.zip` you've just downloaded inside it's own folder.
+![image](https://user-images.githubusercontent.com/25492573/224986199-cf6340b3-a456-4760-a11d-5552cdff9ed0.png)
+_Example of how it might look_
+
+<a name="switching-php-version"/>
+
+### Step 3: Switching to the new PHP version
+To switch your PHP version in Laragon is really simple.
+All you have to do is go to:
+ _Laragon > Menu > PHP > Version [current verison] > Select your desired version from this list_
+![image](https://user-images.githubusercontent.com/25492573/224986903-1d57e8ae-4cc3-4cae-a242-f51519d318b9.png)
+
+
+<a name="updating-environment-variable-path"/>
+
+### Step 4: Updating PHP Environment Variable Path
+_You have to do this step every time you switch between PHP versions._
+If you use PHP through the CLI (for example `php artisan serve` with Laravel) it's important that you also change the PATH in your environment variables.
+
+Laragon allows you to quickly do this by going to:
+![image](https://user-images.githubusercontent.com/25492573/224987455-fb6c998e-915b-4f1f-a102-da62a7aa9a3c.png)
+ _Laragon > Menu > Tools > Path > Add Laragon to Path_
+
+This will automatically add everything from your Laragon installation to the PATH
+![image](https://user-images.githubusercontent.com/25492573/224990138-26b717cd-98aa-48c0-adc0-1ddd3ce8be5c.png)
+
+Make sure that you restart your terminal for these changes to take place. Run the command `php -v` to make sure you're on the correct version.


### PR DESCRIPTION
Since the [forum](https://forum.laragon.org/) is down due to financial difficulties.
Maybe it's an idea to make a README of all the old tutorials that are linked within Laragon. Since they currently link to a forum that's not working anymore. This could potentially help new users of Laragon. 

For now I made a quick and simple README on how to add another PHP version to Laragon. Maybe this could be improved a bit, but it's a start. You can view it in my fork:
[how-to-add-another-php-version.md](https://github.com/ProjectAsphaleia/laragon/blob/57159bf9973c4bad5ab246c1660d42a6ffb51b1f/documentation/how-to-add-another-php-version.md)

Don't know if other people are a fan of this as well.